### PR TITLE
Allow connecting to Angular dev server on a different port

### DIFF
--- a/main.js
+++ b/main.js
@@ -41,12 +41,12 @@ app.on('ready', () => {
   log.info('app ready')
   log.debug('argv', process.argv);
   log.debug('options', options);
-  
+
   app.setAppUserModelId("io.unite.desktop");
-  
+
   // initialize the authentication filter
   _auth.init();
-  
+
   initMainWindow();
   init.start(mainWindow);
 });
@@ -105,7 +105,7 @@ function initMainWindow() {
 
   // and load the index.html of the app.
   if (options.dev) {
-    mainWindow.loadURL('http://localhost:4200');
+    mainWindow.loadURL(`http://localhost:${options.devport}`);
   } else {
     mainWindow.loadURL(url.format({
       protocol: 'file:',

--- a/modules/daemon/daemon.js
+++ b/modules/daemon/daemon.js
@@ -94,7 +94,7 @@ exports.start = function (wallets) {
       wallets = wallets.map(wallet => `-wallet=${wallet}`);
       log.info(`starting daemon ${daemonPath} ${process.argv} ${wallets}`);
 
-      const child = spawn(daemonPath, [...process.argv, "-rpccorsdomain=http://localhost:4200", ...wallets])
+      const child = spawn(daemonPath, [...process.argv, `-rpccorsdomain=http://localhost:${options.devport}`, ...wallets])
         .on('close', code => {
           if (code !== 0) {
             reject();
@@ -186,7 +186,7 @@ function askForDeletingCookie() {
       electron.dialog.showMessageBox({
         type: 'warning',
         buttons: ['Yes', 'No'],
-        message: `It seems like you already have an instance of UnitE running, do you want to connect to that instead? 
+        message: `It seems like you already have an instance of UnitE running, do you want to connect to that instead?
                   If you think you're having issues starting the application, select no.`
       }, (response) => {
         if (response === 1) {

--- a/modules/options.js
+++ b/modules/options.js
@@ -35,7 +35,7 @@ exports.parse = function() {
 
   // make a copy of process.argv, because we'll be changing it
   // which messes with the map operator
-  const args = process.argv.slice(0); 
+  const args = process.argv.slice(0);
 
   args.map((arg, index) => {
     let nDashes = arg.lastIndexOf('-') + 1;
@@ -48,6 +48,11 @@ exports.parse = function() {
       let verboseLevel = isVerboseLevel(arg);
       if (verboseLevel) {
         options['verbose'] = verboseLevel;
+        return ;
+      }
+      if (arg.includes('=')) {
+        arg = arg.split('=');
+        options[arg[0]] = arg[1];
         return ;
       }
     } else if (nDashes === 1) { /* single-dash: core argument */
@@ -71,6 +76,9 @@ exports.parse = function() {
       : options.regtest
         ? 18443  // default regtest port
         : 8332 ; // default mainnet port
+
+  // Angular development server port
+  options.devport = options.devport || 4200;
   _options = options;
   return options;
 }

--- a/modules/webrequest/http-auth.js
+++ b/modules/webrequest/http-auth.js
@@ -21,6 +21,7 @@ exports.init = function () {
         // clone it
         const url = new URL(details.url);
         const u = url.hostname + ":" + url.port;
+        const options = _options.get();
 
         if (isWhitelisted(u)) {
             let headers = Object.assign({}, details.requestHeaders);
@@ -28,7 +29,7 @@ exports.init = function () {
             // get authentication
             let auth = getAuthentication(u);
 
-            if(auth === undefined && u === "localhost:4200") {
+            if(auth === undefined && u === `localhost:${options.devport}`) {
                 auth = false;
             }
 
@@ -95,7 +96,7 @@ exports.removeWalletAuthentication = () => {
 
 function loadDev() {
     let options = _options.get();
-    let key = 'localhost:4200';
+    let key = `localhost:${options.devport}`;
     let value = {
         name: "dev",
         auth: false


### PR DESCRIPTION
This change allows us to run the Angular dev server on a different port
than the default of 4200. The Electron application receives a new
argument, `--devport=xxxx`, used in concert with `ng serve --port=xxxx`.

Signed-off-by: Mihai Ciumeica <mihai@thirdhash.com>