### PR TITLE
Allow controlling transaction fee

### DIFF
--- a/src/app/_test/wallet-test/send-test/send-mock.service.ts
+++ b/src/app/_test/wallet-test/send-test/send-mock.service.ts
@@ -19,7 +19,7 @@
 import { Observable } from 'rxjs/Observable';
 import { Injectable } from '@angular/core';
 
-const SendService_OBJECT: any = {file: {}};
+const SendService_OBJECT: any = {file: {}, fee: 0.015};
 
 @Injectable()
 export class SendMockService {

--- a/src/app/modals/modals.module.ts
+++ b/src/app/modals/modals.module.ts
@@ -42,6 +42,7 @@ import { PasswordComponent } from './shared/password/password.component';
 import { SnackbarService } from '../core/snackbar/snackbar.service';
 import { ManageWidgetsComponent } from './manage-widgets/manage-widgets.component';
 import { SendConfirmationModalComponent } from 'app/modals/send-confirmation-modal/send-confirmation-modal.component';
+import { FeeOptionsComponent } from './send-confirmation-modal/fee-options/fee-options.component';
 
 @NgModule({
   imports: [
@@ -62,7 +63,8 @@ import { SendConfirmationModalComponent } from 'app/modals/send-confirmation-mod
     EncryptwalletComponent,
     AlertComponent,
     ManageWidgetsComponent,
-    SendConfirmationModalComponent
+    SendConfirmationModalComponent,
+    FeeOptionsComponent,
   ],
   exports: [
     ClipboardModule

--- a/src/app/modals/send-confirmation-modal/fee-options/fee-options.component.html
+++ b/src/app/modals/send-confirmation-modal/fee-options/fee-options.component.html
@@ -1,0 +1,44 @@
+<div class="fee-options" fxLayout="column" fxLayoutGap="10px">
+
+  <mat-checkbox name="subtract_fee"
+                [(ngModel)]="send.subtractFeeFromAmount"
+                (change)="updateSelectedFee()" >
+    Subtract fee from amount
+  </mat-checkbox>
+
+  <mat-radio-group name="fee_determination" [(ngModel)]="send.feeDetermination" fxLayout="column" (change)="updateSelectedFee()">
+    <div class="input-height align-children">
+      <mat-radio-button value="default">
+        Default fee
+      </mat-radio-button>
+    </div>
+
+    <div class="align-children">
+      <mat-radio-button value="confirmation">
+        Confirmation target:
+      </mat-radio-button>
+      <mat-form-field class="spaced">
+        <mat-select name="confirmation_target"
+                    [(ngModel)]="send.confirmationTarget"
+                    [disabled]="send.feeDetermination !== 'confirmation'">
+          <mat-option *ngFor="let confTarget of CONFIRMATION_TARGETS" [value]="confTarget">
+            {{confTarget}}
+          </mat-option>
+        </mat-select>
+      </mat-form-field>
+      <span>blocks</span>
+    </div>
+
+    <div class="align-children">
+      <mat-radio-button value="custom">Custom fee:</mat-radio-button>
+      <mat-form-field class="spaced">
+        <input matInput type="number" name="custom_fee"
+               [(ngModel)]="send.customFee" [disabled]="send.feeDetermination !== 'custom'"
+               step="0.00001">
+      </mat-form-field>
+      <span>UTE/kbyte</span>
+    </div>
+
+  </mat-radio-group>
+
+</div>

--- a/src/app/modals/send-confirmation-modal/fee-options/fee-options.component.scss
+++ b/src/app/modals/send-confirmation-modal/fee-options/fee-options.component.scss
@@ -1,0 +1,18 @@
+@import "./src/assets/_config"; // import shared colors etc.
+
+.fee-options {
+  text-align: left;
+}
+
+.input-height {
+  min-height: 4em;
+}
+
+.align-children {
+  display: flex;
+  align-items: center
+}
+
+.spaced {
+  margin: 0 8px;
+}

--- a/src/app/modals/send-confirmation-modal/fee-options/fee-options.component.spec.ts
+++ b/src/app/modals/send-confirmation-modal/fee-options/fee-options.component.spec.ts
@@ -1,0 +1,38 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { MaterialModule } from 'app/core-ui/material/material.module';
+
+import { CoreModule } from 'app/core/core.module';
+import { FeeOptionsComponent } from './fee-options.component';
+import { SendService } from 'app/wallet/wallet/send/send.service';
+import { SendMockService } from 'app/_test/wallet-test/send-test/send-mock.service';
+
+describe('FeeOptionsComponent', () => {
+  let component: FeeOptionsComponent;
+  let fixture: ComponentFixture<FeeOptionsComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        CoreModule.forRoot(),
+        BrowserAnimationsModule,
+        MaterialModule,
+      ],
+      declarations: [ FeeOptionsComponent ],
+      providers: [
+        { provide: SendService, useClass: SendMockService },
+      ],
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(FeeOptionsComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/modals/send-confirmation-modal/fee-options/fee-options.component.ts
+++ b/src/app/modals/send-confirmation-modal/fee-options/fee-options.component.ts
@@ -1,0 +1,48 @@
+import {
+  Component,
+  EventEmitter,
+  Input,
+  Output,
+  OnInit,
+} from '@angular/core';
+
+import { SnackbarService } from 'app/core/snackbar/snackbar.service';
+import { TransactionBuilder, FeeDetermination } from 'app/wallet/wallet/send/transaction-builder.model';
+import { SendService } from 'app/wallet/wallet/send/send.service';
+
+@Component({
+  selector: 'app-fee-options',
+  templateUrl: './fee-options.component.html',
+  styleUrls: ['./fee-options.component.scss']
+})
+export class FeeOptionsComponent implements OnInit {
+
+  @Input() send: TransactionBuilder;
+
+  @Output() updateFee: EventEmitter<number> = new EventEmitter<number>();
+
+  CONFIRMATION_TARGETS: number[] = [2, 4, 6, 12, 24, 48, 144, 504, 1008];
+
+  constructor(
+    private sendService: SendService,
+    private snackbar: SnackbarService,
+  ) { }
+
+  ngOnInit() {
+    if (!this.send) {
+      this.send = new TransactionBuilder();
+    }
+  }
+
+  updateSelectedFee(): void {
+    this.sendService.getTransactionFee(this.send)
+      .subscribe(x => {
+        this.send.selectedFee = x.fee;
+        this.updateFee.emit(this.send.selectedFee);
+      },
+      e => {
+        this.snackbar.open(e.message);
+      });
+  }
+
+}

--- a/src/app/modals/send-confirmation-modal/send-confirmation-modal.component.html
+++ b/src/app/modals/send-confirmation-modal/send-confirmation-modal.component.html
@@ -7,17 +7,6 @@
 
   <!--TX confirmation-->
   <div class="tx-confirmation">
-    <div class="tx-info">
-      <!-- if public -->
-      <div class="public" *ngIf="transactionType === TxType.PUBLIC">
-        <mat-icon class="icon public" fontSet="uniteIcon" fontIcon="unite-public"></mat-icon>
-        <div class="title">Public transaction</div>
-        <p class="help-text">
-          Sender, Receiver & transaction amount will be publicly visible on the blockchain
-        </p>
-      </div>
-    </div>
-
     <div class="tx-amount">
       <span class="big">{{ sendAmount.getIntegerPart() }}</span>
       <span *ngIf="sendAmount.ifDotExist()">
@@ -37,10 +26,23 @@
     </div>
 
     <p class="fee-info">
-      Transaction fee:<span class="amount">{{ transactionAmount.getFee() }} UTE</span><span class="fiat">&asymp; 0.05 USD</span><br>
-      Total amount:<span
-      class="amount">{{ transactionAmount.getAmountWithFee(sendAmount.getAmount()) }} UTE</span><span class="fiat">&asymp; 3.47 USD</span>
+      Transaction fee:<span class="amount">{{ transactionAmount.getFee() }} UTE</span><span class="fiat">&asymp; 0.05 USD</span>
+      <button mat-button color="primary"
+              (click)="showAdvancedFeeOptions = !showAdvancedFeeOptions" matTooltip="Edit fee"
+              *ngIf="!showAdvancedFeeOptions">
+        <mat-icon fontSet="uniteIcon" fontIcon="unite-pen-1"></mat-icon>
+        Edit
+      </button>
     </p>
+
+    <div class="section advanced" fxLayout="column" fxLayoutGap="8px" *ngIf="showAdvancedFeeOptions">
+      <app-fee-options [send]="send" (updateFee)="setTransactionFee($event)"></app-fee-options>
+    </div><!-- .section.advanced -->
+
+    <div class="total-amount-info">
+      Total amount:<span
+      class="amount">{{ getAmountWithFee() }} UTE</span><span class="fiat">&asymp; 3.47 USD</span>
+    </div>
   </div><!-- TX confirmation -->
 
 </div><!-- .dialog-content -->

--- a/src/app/modals/send-confirmation-modal/send-confirmation-modal.component.scss
+++ b/src/app/modals/send-confirmation-modal/send-confirmation-modal.component.scss
@@ -14,10 +14,7 @@
 }
 
 .help-text {
-  // FIXME: switch to: @extend %help-text;
-  @extend %disable-select;
-  color: $text-muted;
-  font-size: 11px;
+  @extend %help-text;
   margin-bottom: 25px;
   cursor: help;
 }
@@ -90,11 +87,15 @@
 }
 
 .fee-info {
-  // FIXME: switch to: @extend %help-text;
-  @extend %disable-select;
-  color: $text-muted;
-  font-size: 11px;
+  @extend %help-text;
   margin: 30px 0 0;
+  & > .amount {
+    margin: 0 0 0 10px;
+  }
+}
+
+.total-amount-info {
+  @extend %help-text;
   & > .amount {
     margin: 0 0 0 10px;
   }
@@ -104,4 +105,12 @@
   @extend .fee-info;
   margin-top: 20px;
   padding: 0 70px;
+}
+
+.advanced { // "advanced options" fields
+  background: mix(white, $bg);
+  border-top: 1px dashed darken($bg, 7%);
+  border-bottom: 1px dashed darken($bg, 7%);
+  padding: 8px 24px 0;
+  margin: 8px 0 8px;
 }

--- a/src/app/modals/send-confirmation-modal/send-confirmation-modal.component.spec.ts
+++ b/src/app/modals/send-confirmation-modal/send-confirmation-modal.component.spec.ts
@@ -25,6 +25,7 @@ import { MaterialModule } from '../../core-ui/material/material.module';
 
 import { SnackbarService } from '../../core/snackbar/snackbar.service';
 
+import { FeeOptionsComponent } from './fee-options/fee-options.component';
 import { SendConfirmationModalComponent } from './send-confirmation-modal.component';
 import { SendService } from 'app/wallet/wallet/send/send.service';
 import { SendMockService } from 'app/_test/wallet-test/send-test/send-mock.service';
@@ -42,7 +43,10 @@ describe('SendConfirmationModalComponent', () => {
         MaterialModule,
         MatFormFieldModule // check if this is required. If so, move into CoreUi.
       ],
-      declarations: [ SendConfirmationModalComponent ],
+      declarations: [
+        SendConfirmationModalComponent,
+        FeeOptionsComponent,
+      ],
       providers: [
         SnackbarService,
         {provide: SendService, useClass: SendMockService},

--- a/src/app/modals/send-confirmation-modal/send-confirmation-modal.component.ts
+++ b/src/app/modals/send-confirmation-modal/send-confirmation-modal.component.ts
@@ -41,6 +41,7 @@ export class SendConfirmationModalComponent implements OnInit {
   sendAddress: string = '';
   receiverName: string = '';
   transactionAmount: Fee = new Fee(0);
+  showAdvancedFeeOptions: boolean = false;
 
   constructor(private dialogRef: MatDialogRef<SendConfirmationModalComponent>,
               private sendService: SendService) {
@@ -63,7 +64,7 @@ export class SendConfirmationModalComponent implements OnInit {
     * Set the confirmation modal data for tx
     */
   setTxDetails(): void {
-    this.getTransactionFee();
+    this.updateTransactionFee();
 
     this.sendAddress = this.send.toAddress;
     this.transactionType = this.send.input;
@@ -71,10 +72,22 @@ export class SendConfirmationModalComponent implements OnInit {
     this.receiverName = this.send.toLabel;
   }
 
-  getTransactionFee() {
+  updateTransactionFee(): void {
     this.sendService.getTransactionFee(this.send).subscribe(fee => {
       this.transactionAmount = new Fee(fee.fee);
     });
+  }
+
+  getAmountWithFee(): number {
+    if (this.send.subtractFeeFromAmount) {
+      return this.sendAmount.getAmount();
+    }
+
+    return this.transactionAmount.getAmountWithFee(this.sendAmount.getAmount());
+  }
+
+  setTransactionFee(fee: number): void {
+    this.transactionAmount = new Fee(fee);
   }
 
 }

--- a/src/app/wallet/wallet/send/send.component.html
+++ b/src/app/wallet/wallet/send/send.component.html
@@ -53,31 +53,37 @@
       </mat-card><!-- .pay-to -->
 
       <!-- Send amount % buttons -->
-      <mat-card class="send-amount" fxLayout="row" fxLayoutGap="15px" fxLayoutAlign="start center">
-        <mat-form-field fxFlex="0 0 150px">
-          <!-- Send amount -->
-          <input matInput type="text" name="sendAmount" placeholder="Amount to send" [(ngModel)]="send.amount"
-                 (input)="verifyAmount()"
-                 [ngClass]="{'verify-sucess': checkAmount() === true, 'verify-error': checkAmount() === false }"
-                 [disabled]="send.subtractFeeFromAmount">
-        </mat-form-field>
-        <mat-checkbox name="send_all" [(ngModel)]="send.subtractFeeFromAmount" (click)="sendAllBalance()"
-                      class="send-all">
-          Send All
-        </mat-checkbox>
-        <!-- Choose currency -->
-        <mat-select class="underliningSelect" fxFlex="0 0 70px" name="currency" [(ngModel)]="send.currency"
-                    placeholder="Currency">
-          <mat-option value="ute">UTE</mat-option>
-        </mat-select>
-        <!-- Send buttons -->
-        <div class="actions" fxFlex="1 1 100%">
-          <button mat-raised-button color="primary" class="validate" (click)="onSubmit()"
-                  [disabled]="!checkAddress() || !checkAmount()">
-            <mat-icon fontSet="uniteIcon" fontIcon="unite-check"></mat-icon>
-            Make payment
-          </button>
-        </div><!-- .actions -->
+      <mat-card class="send-amount">
+        <div class="title">
+          Amount
+        </div>
+
+        <div class="section" fxLayout="row" fxLayoutGap="15px" fxLayoutAlign="start center">
+          <mat-form-field fxFlex="0 0 150px">
+            <!-- Send amount -->
+            <input matInput type="text" name="sendAmount" placeholder="Amount to send" [(ngModel)]="send.amount"
+                   (input)="verifyAmount()"
+                   [ngClass]="{'verify-sucess': checkAmount() === true, 'verify-error': checkAmount() === false }"
+                   [disabled]="send.sendAll">
+          </mat-form-field>
+          <mat-checkbox name="send_all" [(ngModel)]="send.sendAll" (click)="sendAllBalance()"
+                        class="send-all">
+            Send All
+          </mat-checkbox>
+          <!-- Choose currency -->
+          <mat-select class="underliningSelect" fxFlex="0 0 70px" name="currency" [(ngModel)]="send.currency"
+                      placeholder="Currency">
+            <mat-option value="ute">UTE</mat-option>
+          </mat-select>
+          <!-- Send buttons -->
+          <div class="actions" fxFlex="1 1 100%">
+            <button mat-raised-button color="primary" class="validate" (click)="onSubmit()"
+                    [disabled]="!checkAddress() || !checkAmount()">
+              <mat-icon fontSet="uniteIcon" fontIcon="unite-check"></mat-icon>
+              Make payment
+            </button>
+          </div><!-- .actions -->
+        </div>
       </mat-card><!-- .send-amount -->
 
 

--- a/src/app/wallet/wallet/send/send.component.ts
+++ b/src/app/wallet/wallet/send/send.component.ts
@@ -273,7 +273,8 @@ export class SendComponent implements OnInit {
   }
 
   sendAllBalance(): void {
-    this.send.amount = (!this.send.subtractFeeFromAmount) ? this.getBalance(this.send.input) : null;
+    this.send.amount = (!this.send.sendAll) ? this.getBalance(this.send.input) : null;
+    this.send.subtractFeeFromAmount = this.send.sendAll;
   }
 
 }

--- a/src/app/wallet/wallet/send/transaction-builder.model.ts
+++ b/src/app/wallet/wallet/send/transaction-builder.model.ts
@@ -21,6 +21,12 @@ export enum TxType {
   PUBLIC = 'ute',
 }
 
+export enum FeeDetermination {
+  DEFAULT = 'default',
+  CONFIRMATION = 'confirmation',
+  CUSTOM = 'custom',
+}
+
 export class TransactionBuilder {
   input: TxType = TxType.PUBLIC;
   output: TxType = TxType.PUBLIC;
@@ -36,7 +42,14 @@ export class TransactionBuilder {
   isMine: boolean;
   currency: string = 'ute';
   ringsize: number = 8;
+  sendAll: boolean = false;
   subtractFeeFromAmount: boolean = false;
+
+  feeDetermination: string = FeeDetermination.DEFAULT;
+  selectedFee: number;
+  customFee: number = 0.00001;
+  confirmationTarget: number = 2;
+
   estimateFeeOnly: boolean = true;
 
   constructor() {

--- a/src/assets/_config.scss
+++ b/src/assets/_config.scss
@@ -103,6 +103,12 @@ $break-xhd: 2200px;
   cursor: text;
 }
 
+// help text
+%help-text {
+  @extend %disable-select;
+  color: $text-muted;
+  font-size: 11px;
+}
 
 // Transition effects
 %tfx {


### PR DESCRIPTION
The send confirmation dialog will now allow the user to estimate the
transaction fee to get a given confirmation target, as well as set
the fee directly; see issue #19.

![image](https://user-images.githubusercontent.com/172272/49286200-d5dcef80-f499-11e8-872a-2085517cc212.png)

Signed-off-by: Mihai Ciumeica <mihai@thirdhash.com>