### PR TITLE
Use headless Chrome to run unit tests

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -56,7 +56,7 @@ module.exports = function (config) {
     colors: true,
     logLevel: config.LOG_INFO,
     autoWatch: true,
-    browsers: ['Chrome'],
+    browsers: ['ChromeHeadless'],
     singleRun: false
   });
 };


### PR DESCRIPTION
It speeds up the test run by a few seconds and avoids launching an annoying browser window in your face.