### PR TITLE
Remove potentially compromising logs

### DIFF
--- a/src/app/modals/createwallet/createwallet.component.ts
+++ b/src/app/modals/createwallet/createwallet.component.ts
@@ -157,7 +157,6 @@ export class CreateWalletComponent implements OnDestroy {
         this.passwordVerify = '';
         break;
       case 3:
-      this.log.d('step 3 execution, password=', this.password)
         this._passphraseService.generateMnemonic(
           this.mnemonicCallback.bind(this), this.password
         );
@@ -197,7 +196,6 @@ export class CreateWalletComponent implements OnDestroy {
     }
 
     this.wordsVerification = Object.assign({}, this.words);
-    this.log.d(`word string: ${this.words.join(' ')}`);
   }
 
   public importMnemonicSeed(): void {


### PR DESCRIPTION
Removed key mnemonic and wallet lock password from debug log. The log was written to the browser's developer console and not persisted to disk, but better safe than sorry.

Thanks to Andreu for noticing this.