### PR TITLE
Stake coins remotely in the wallet

### DIFF
--- a/src/app/core-ui/main/main-view.component.html
+++ b/src/app/core-ui/main/main-view.component.html
@@ -39,6 +39,15 @@
               </a>
 
               <a class="sidebar-item-link"
+                routerLinkActive="active" [routerLink]="'/wallet/stake'">
+                <mat-list-item class="sidebar-item">
+                  <mat-icon class="icon" fontSet="uniteIcon"
+                    fontIcon="unite-refresh"></mat-icon>
+                  <span class="text">Stake Remotely</span>
+                </mat-list-item>
+              </a>
+
+              <a class="sidebar-item-link"
                 routerLinkActive="active" [routerLink]="'/wallet/receive'">
                 <mat-list-item class="sidebar-item">
                   <mat-icon class="icon" fontSet="uniteIcon"

--- a/src/app/core/rpc/commands.ts
+++ b/src/app/core/rpc/commands.ts
@@ -41,6 +41,7 @@ enum Commands {
   RUNSTRINGCOMMAND = 'runstringcommand',
   SENDTYPETO = 'sendtypeto',
   SIGNMESSAGE = 'signmessage',
+  STAKEAT = 'stakeat',
   VALIDATEADDRESS = 'validateaddress',
   VERIFYMESSAGE = 'verifymessage',
   WALLETLOCK = 'walletlock',

--- a/src/app/core/rpc/rpc.service.ts
+++ b/src/app/core/rpc/rpc.service.ts
@@ -196,6 +196,13 @@ export class RpcService implements OnDestroy {
       typein, typeout, outputs, comment, commentTo, testFee, coinControl
     ]);
   }
+
+  stakeat(output: Outputs, testFee?: boolean, coinControl?: CoinControl) {
+    testFee = testFee || false;
+    coinControl = coinControl || null;
+
+    return this.call(Commands.STAKEAT, [output, testFee, coinControl]);
+  }
 }
 
 export { Commands } from './commands';

--- a/src/app/wallet/wallet.routing.ts
+++ b/src/app/wallet/wallet.routing.ts
@@ -27,6 +27,7 @@ import {
   SendComponent,
   SettingsComponent,
 } from './wallet/wallet.module';
+import { RemoteStakeComponent } from './wallet/remote-stake/remote-stake.component';
 
 //   { path: '', redirectTo: '/wallet/overview', pathMatch: 'full' },
 const routes: Routes = [
@@ -34,6 +35,7 @@ const routes: Routes = [
   { path: 'overview', component: OverviewComponent, data: { title: 'Overview' } },
   { path: 'receive', component: ReceiveComponent, data: { title: 'Receive' } },
   { path: 'send', component: SendComponent, data: { title: 'Send' } },
+  { path: 'stake', component: RemoteStakeComponent, data: { title: 'Stake Remotely' } },
   { path: 'history/:search', component: HistoryComponent, data: { title: 'History' } },
   { path: 'history', component: HistoryComponent, data: { title: 'History' } },
   { path: 'address-book', component: AddressBookComponent, data: { title: 'Address Book' } },

--- a/src/app/wallet/wallet/remote-stake/remote-stake.component.html
+++ b/src/app/wallet/wallet/remote-stake/remote-stake.component.html
@@ -1,0 +1,59 @@
+<div class="send container-block disable-select" fxLayout="row" fxLayoutGap="35px">
+
+  <div class="from-box" fxFlex="0 0 320px">
+    <mat-card>
+      <div class="title">Amount to stake</div>
+
+      <div class="balance">
+        <div class="desc">Selected amount: <span class="amount">{{ selectedBalance.toString() }}</span></div>
+      </div>
+
+      <form>
+        <mat-radio-group class="payment-source" name="payment_source" [(ngModel)]="paymentSource" (change)="onChangePaymentSource()" fxLayout="column">
+          <mat-radio-button value="default">
+            Any available coins
+          </mat-radio-button>
+          <mat-radio-button value="coin_control">
+            Specific coins (advanced)
+          </mat-radio-button>
+        </mat-radio-group>
+      </form>
+
+      <app-coin-selection *ngIf="paymentSource === 'coin_control'" (selectCoins)="updateSelection($event)"></app-coin-selection>
+    </mat-card>
+  </div><!-- .from-box -->
+
+
+  <div class="to-box" fxFlex="1 1 100%">
+    <form name="walletSendForm">
+
+      <mat-card class="pay-to" *ngIf="type === 'sendPayment'" fxLayout="column">
+        <div class="title">
+          Staking node
+        </div>
+
+        <!-- Receiver's address/label -->
+        <div class="section receiver-address output-{{i}}" *ngFor="let txo of send.outputs; let i = index">
+          <app-send-output [txo]="txo" [first]="i === 0"
+                           (remove)="this.send.removeOutput(i)"
+                           (sendAllBalance)="this.sendAllBalance(txo)"
+                           (openLookup)="this.openLookup(txo)"
+          ></app-send-output>
+        </div><!-- .receiver-address.section -->
+
+        <!-- Send buttons -->
+        <div class="actions" fxLayout="row" fxFlex="1 1 100%">
+          <div fxFlex="1 1 auto"></div>
+          <button mat-raised-button color="primary" class="validate" (click)="onSubmit()"
+                  [disabled]="!this.send.validAddress || !this.send.validAmount">
+            <mat-icon fontSet="uniteIcon" fontIcon="unite-check"></mat-icon>
+            Stake
+          </button>
+        </div><!-- .actions -->
+
+      </mat-card><!-- .pay-to -->
+
+    </form><!-- walletSendForm -->
+  </div><!-- .to-box -->
+
+</div><!-- .container -->

--- a/src/app/wallet/wallet/remote-stake/remote-stake.component.scss
+++ b/src/app/wallet/wallet/remote-stake/remote-stake.component.scss
@@ -1,0 +1,3 @@
+@import "./src/assets/_config"; // import shared colors etc.
+
+@import "../send/send.component";

--- a/src/app/wallet/wallet/remote-stake/remote-stake.component.spec.ts
+++ b/src/app/wallet/wallet/remote-stake/remote-stake.component.spec.ts
@@ -1,0 +1,59 @@
+import { async, ComponentFixture, TestBed, inject } from '@angular/core/testing';
+import { MatDialogRef } from '@angular/material';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+
+import { ModalsModule } from 'app/modals/modals.module';
+import { CoreUiModule } from 'app/core-ui/core-ui.module';
+import { CoreModule, RpcStateService, Commands } from 'app/core/core.module';
+import { SharedModule } from 'app/wallet/shared/shared.module';
+
+import { RemoteStakeComponent } from './remote-stake.component';
+import { CoinSelectionComponent } from '../send/coin-selection/coin-selection.component';
+import { SendOutputComponent } from '../send/send-output/send-output.component';
+import { RemoteStakeService } from './remote-stake.service';
+import mockgetwalletinfo from 'app/_test/core-test/rpc-test/mock-data/getwalletinfo.mock';
+
+describe('RemoteStakeComponent', () => {
+  let component: RemoteStakeComponent;
+  let fixture: ComponentFixture<RemoteStakeComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [
+        RemoteStakeComponent,
+        CoinSelectionComponent,
+        SendOutputComponent,
+      ],
+      imports: [
+        SharedModule,
+        CoreModule.forRoot(),
+        CoreUiModule.forRoot(),
+        ModalsModule.forRoot(),
+        NoopAnimationsModule
+      ],
+      providers: [
+        RemoteStakeService,
+        { provide: MatDialogRef },
+      ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(inject([RpcStateService], (svc: RpcStateService) => {
+    svc.set(Commands.GETWALLETINFO, mockgetwalletinfo);
+
+    fixture = TestBed.createComponent(RemoteStakeComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  }));
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should display the amount that can be staked remotely', () => {
+    const nav = fixture.nativeElement;
+    const amountHtml = nav.querySelectorAll('.amount')[0].innerHTML;
+    expect(amountHtml).toBe('249.5795902');
+  });
+});

--- a/src/app/wallet/wallet/remote-stake/remote-stake.component.ts
+++ b/src/app/wallet/wallet/remote-stake/remote-stake.component.ts
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2019 The Unit-e developers
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+import { Component } from '@angular/core';
+import { SendComponent } from '../send/send.component';
+import { RpcService, RpcStateService, SnackbarService } from 'app/core/core.module';
+import { ModalsHelperService } from 'app/modals/modals.module';
+import { MatDialog, MatDialogConfig } from '@angular/material';
+import { RemoteStakeService } from './remote-stake.service';
+import { SendConfirmationModalComponent } from 'app/modals/send-confirmation-modal/send-confirmation-modal.component';
+
+@Component({
+  selector: 'app-remote-stake',
+  templateUrl: './remote-stake.component.html',
+  styleUrls: ['./remote-stake.component.scss']
+})
+export class RemoteStakeComponent extends SendComponent {
+
+  constructor(
+    service: RemoteStakeService,
+    _rpc: RpcService,
+    _rpcState: RpcStateService,
+    modals: ModalsHelperService,
+    dialog: MatDialog,
+    flashNotification: SnackbarService
+  ) {
+    super(service, _rpc, _rpcState, modals, dialog, flashNotification);
+  }
+
+  openSendConfirmationModal() {
+    const txt = `Do you really want to stake ${this.send.amount} UTE at ${this.send.toAddress}?`;
+
+    const dialogConfig = new MatDialogConfig();
+    dialogConfig.data = {
+      service: this.sendService,
+      dialogContent: txt,
+      send: this.send,
+    };
+
+    const dialogRef = this.dialog.open(SendConfirmationModalComponent, dialogConfig);
+    dialogRef.componentInstance.onConfirm.subscribe(() => {
+      dialogRef.close();
+      this.pay();
+    });
+  }
+}

--- a/src/app/wallet/wallet/remote-stake/remote-stake.service.spec.ts
+++ b/src/app/wallet/wallet/remote-stake/remote-stake.service.spec.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2019 The Unit-e developers
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+import { TestBed, inject } from '@angular/core/testing';
+
+import { RemoteStakeService } from './remote-stake.service';
+import { SharedModule } from 'app/wallet/shared/shared.module';
+import { CoreModule } from 'app/core/core.module';
+import { CoreUiModule } from 'app/core-ui/core-ui.module';
+import { WalletModule } from '../wallet.module';
+
+describe('RemoteStakeService', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        SharedModule,
+        CoreModule.forRoot(),
+        CoreUiModule.forRoot(),
+        WalletModule.forRoot(),
+      ],
+      providers: [RemoteStakeService]
+    });
+  });
+
+  it('should be created', inject([RemoteStakeService], (service: RemoteStakeService) => {
+    expect(service).toBeTruthy();
+  }));
+});

--- a/src/app/wallet/wallet/remote-stake/remote-stake.service.ts
+++ b/src/app/wallet/wallet/remote-stake/remote-stake.service.ts
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2019 The Unit-e developers
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+import { Injectable } from '@angular/core';
+import { MatDialog } from '@angular/material';
+import { Observable } from 'rxjs';
+import { Log } from 'ng2-logger'
+
+import { RpcService } from '../../../core/core.module';
+
+import { TransactionBuilder } from '../send/transaction-builder.model';
+import { SendService } from '../send/send.service';
+
+
+@Injectable()
+export class RemoteStakeService extends SendService {
+
+  log: any = Log.create('remote-stake.service');
+
+  constructor(_rpc: RpcService,
+              dialog: MatDialog) {
+    super(_rpc, dialog);
+  }
+
+  /**
+   * Executes or estimates the fee for a remote staking transaction.
+   * Estimates if tx.estimateFeeOnly === true.
+   */
+  protected send(tx: TransactionBuilder): Observable<any> {
+    const [coinControl, outputs] = this.getSendParameters(tx);
+    if (outputs.length < 1) {
+      return Observable.throw('Transaction has no outputs.');
+    }
+
+    return this._rpc.stakeat(outputs[0], tx.estimateFeeOnly, coinControl);
+  }
+}

--- a/src/app/wallet/wallet/wallet.module.ts
+++ b/src/app/wallet/wallet/wallet.module.ts
@@ -50,6 +50,8 @@ import { BumpFeeModalComponent } from './shared/transaction-table/bump-fee-modal
 import { CoinSelectionComponent } from './send/coin-selection/coin-selection.component';
 import { SendOutputComponent } from './send/send-output/send-output.component';
 import { SettingsComponent } from './settings/settings.component';
+import { RemoteStakeComponent } from './remote-stake/remote-stake.component';
+import { RemoteStakeService } from './remote-stake/remote-stake.service';
 
 
 @NgModule({
@@ -78,6 +80,7 @@ import { SettingsComponent } from './settings/settings.component';
     CoinSelectionComponent,
     SendOutputComponent,
     SettingsComponent,
+    RemoteStakeComponent,
   ],
   exports: [
     TransactionsTableComponent,
@@ -110,6 +113,7 @@ export class WalletModule {
       ngModule: WalletModule,
       providers: [
         AddressService,
+        RemoteStakeService,
         SendService,
         SettingsService,
       ]


### PR DESCRIPTION
This commit adds a new page, 'Stake Remotely', similar to the 'Send' page, which allows the user to send some UTE to a remote staking address.

Most of the logic is inherited from the 'Send' component and service; the only visible difference is that the Remote Staking page doesn't allow the user to set multiple destinations.

I could have rolled this functionality into the Send page, but chose to make it separate, to emphasize that the funds are being staked and not spent.

![image](https://user-images.githubusercontent.com/172272/52486252-f53f7980-2bba-11e9-952e-f4050777487f.png)

See also #18.