### PR TITLE
Add test and small refactoring of transaction table

### DIFF
--- a/src/app/core/util/amount.ts
+++ b/src/app/core/util/amount.ts
@@ -115,6 +115,10 @@ export class Amount {
     return true;
   }
 
+  isNegative() {
+    return this.sign < 0;
+  }
+
   negate(): Amount {
     return new Amount(this.digits, -this.sign as Sign);
   }

--- a/src/app/wallet/wallet/shared/transaction-table/transaction-table.component.html
+++ b/src/app/wallet/wallet/shared/transaction-table/transaction-table.component.html
@@ -79,7 +79,7 @@
       <mat-panel-title fxFlex="1 0 155px" fxFlex.lt-md="100" *ngIf="display.amount" class="history_amount">
         <span mat-line>
           <span class="amount"
-                [ngClass]="{'positive': tx.amount.toNumber() > 0, 'negative': tx.amount.toNumber() < 0 }">
+                [ngClass]="{'positive': !tx.amount.isNegative(), 'negative': tx.amount.isNegative() }">
             <span class="big number">{{ tx.amount.getIntegralPart() }}</span><!-- inline element comment hack
             --><span class="point">{{ tx.amount.dot() }}</span><!--
             --><small class="small number">{{ tx.amount.getFractionalPart() || '' }}</small>

--- a/src/app/wallet/wallet/shared/transaction-table/transaction-table.component.spec.ts
+++ b/src/app/wallet/wallet/shared/transaction-table/transaction-table.component.spec.ts
@@ -16,18 +16,16 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-import { async, ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { async, ComponentFixture, TestBed, fakeAsync, tick, inject } from '@angular/core/testing';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
-import { RpcModule } from '../../../../core/rpc/rpc.module';
+import { RpcModule, RpcService } from '../../../../core/rpc/rpc.module';
 import { SharedModule } from '../../../shared/shared.module';
 import { WalletModule } from '../../../wallet/wallet.module';
 import { CoreModule } from '../../../../core/core.module';
 
 import { TransactionsTableComponent } from './transaction-table.component';
-import { TransactionService } from 'app/wallet/wallet/shared/transaction.service';
-import { MockTransactionService } from 'app/wallet/wallet/shared/transaction.mockservice';
-
+import { RpcMockService } from 'app/_test/core-test/rpc-test/rpc-mock.service';
 
 
 describe('TransactionTableComponent', () => {
@@ -42,6 +40,9 @@ describe('TransactionTableComponent', () => {
         RpcModule.forRoot(),
         CoreModule.forRoot(),
         BrowserAnimationsModule
+      ],
+      providers: [
+        { provide: RpcService, useClass: RpcMockService }
       ]
     })
     .compileComponents();
@@ -63,5 +64,26 @@ describe('TransactionTableComponent', () => {
 
   it('should get txService', () => {
     expect(component.txService).toBeDefined();
+  });
+
+  it('should display a list of transactions', () => {
+
+    const promise = new Promise((resolve, reject) => {
+      const result = component.txService.loadTransactions();
+      result.subscribe(() => {
+          fixture.detectChanges();
+
+          const nav = fixture.nativeElement;
+          const amount = nav.querySelectorAll('.amount')[0];
+          expect(amount.className).toContain('positive');
+          expect(amount.innerText).toBe('50.0002584 UTE');
+
+          resolve();
+        },
+        () => { reject(); }
+      );
+    });
+
+    return promise;
   });
 });


### PR DESCRIPTION
We don't need to parse the Amount object to see if it's negative or not.
This commit simplifies this logic, as well as adds a test for it.