### PR TITLE
Avoid exception when logging error to the browser console

### DIFF
--- a/src/app/core-ui/main/release-notification/release-notification.component.ts
+++ b/src/app/core-ui/main/release-notification/release-notification.component.ts
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2017-2018 The Particl developers
+ * Copyright (C) 2018-2019 The Unit-e developers
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -57,6 +58,10 @@ export class ReleaseNotificationComponent implements OnInit, OnDestroy {
   getCurrentClientVersion() {
     this.clientVersionService.getCurrentVersion()
       .subscribe((response: ReleaseNotification) => {
+        if (!response) {
+          return;
+        }
+
         if (response.tag_name) {
           this.latestClientVersion = response.tag_name.substring(1);
         }

--- a/src/app/core/http/client-version.service.ts
+++ b/src/app/core/http/client-version.service.ts
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2017-2018 The Particl developers
+ * Copyright (C) 2018-2019 The Unit-e developers
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -50,7 +51,7 @@ export class ClientVersionService {
    */
   private handleError<T>(operation: string = 'operation', result?: T) {
     return (error: any): Observable<T> => {
-      this.log(`${operation} failed: ${error.message}`);
+      this.log.error(`${operation} failed: ${error.message}`);
 
       // Let the app keep running by returning an empty result.
       return of(result as T);


### PR DESCRIPTION
`ClientVersionService.log` is a Logger object, which exposes the actual logging methods.
When trying to call the Logger directly, an exception was being raised, which cluttered
the browser console.