### PR TITLE
Fix Block Explorer URL

### DIFF
--- a/src/app/modals/createwallet/createwallet.component.html
+++ b/src/app/modals/createwallet/createwallet.component.html
@@ -7,7 +7,7 @@
       UnitE Desktop is a feature-rich client for interacting with UnitE network.<br>
     </p>
     <p class="info">
-      Visit <a href="https://unit-e.io" target="_blank" tabindex="-1">unit-e.io</a> official site for more info, <a href="https://unit-e.news" target="_blank" tabindex="-1">unit-e.news</a> for latest news and <a href="https://unit-e.wiki" target="_blank" tabindex="-1">unit-e.wiki</a> if you need any help
+      Visit <a href="https://unit-e.io" target="_blank" tabindex="-1">unit-e.io</a> official site for more info, and <a href="https://github.com/dtr-org/unit-e/issues" target="_blank" tabindex="-1">the GitHub issues page</a> if you need any help
     </p>
     <div class="subtitle">Create or restore wallet</div>
     <p>

--- a/src/app/wallet/wallet/shared/transaction-table/transaction-table.component.html
+++ b/src/app/wallet/wallet/shared/transaction-table/transaction-table.component.html
@@ -103,7 +103,7 @@
         <div class="tx-detail-item" fxFlex>
           <span fxFlex="0 0 80px">TXID:</span>
           <a fxFlex="1 1 calc(100% - 80px)" class="tx-detail-link"
-              href="https://explorer{{txService.testnet ? '-testnet' : ''}}.unit-e.io/tx/{{tx.txid}}"
+              href="{{ txService.getTransactionUrl(tx) }}"
               target="_blank" matTooltip="Show on Block Explorer">
             {{tx.txid}}</a>
         </div>

--- a/src/app/wallet/wallet/shared/transaction.service.ts
+++ b/src/app/wallet/wallet/shared/transaction.service.ts
@@ -213,6 +213,13 @@ export class TransactionService implements OnDestroy {
     setTimeout(this.loadTransactions.bind(this), 1000);
   }
 
+  /**
+   * Return a transaction's URL in Block Explorer
+   */
+  getTransactionUrl(tx: Transaction): string {
+    return `https://blockbook.thirdhash.com/tx/${tx.txid}`;
+  }
+
   getExportBaseName(): string {
     const now = new Date();
     const dateString = `${now.getFullYear()}-${now.getMonth() + 1}-${now.getDate()}`;


### PR DESCRIPTION
This commit changes the transaction links to point at the currently
deployed BlockBook (https://blockbook.thirdhash.com/). Fixes #59.