### PR TITLE
Order the address book by date

### DIFF
--- a/src/app/core/rpc/rpc-types.ts
+++ b/src/app/core/rpc/rpc-types.ts
@@ -177,3 +177,17 @@ export class TransactionInfo {
   category: string;
   outputs: TransactionOutput[];
 }
+
+export enum AddressPurpose {
+  ANY = 0,
+  RECEIVE = 1,
+  SEND = 2,
+}
+
+// Address, as returned by `filteraddresses`
+export class Address {
+  address: string;
+  label: string;
+  owned: boolean;
+  timestamp: number;
+}

--- a/src/app/core/rpc/rpc.service.ts
+++ b/src/app/core/rpc/rpc.service.ts
@@ -28,6 +28,7 @@ import { IpcService } from '../ipc/ipc.service';
 import { environment } from '../../../environments/environment';
 import { Commands } from './commands';
 import {
+  Address,
   BumpFeeResult,
   CoinControl,
   Outputs,
@@ -35,6 +36,7 @@ import {
   UnspentOutput,
   TransactionInfo,
   WalletInfo,
+  AddressPurpose,
 } from './rpc-types';
 import { Amount } from '../util/amount';
 import { amountConverter } from './rpc-conversions';
@@ -161,15 +163,18 @@ export class RpcService implements OnDestroy {
     return this.call(Commands.BUMPFEE, [txid, options, testFee]);
   }
 
-  filterAddresses(offset?: number, count?: number, sort_code?: 0 | 1, search?: string, match_owned?: 0 | 1 | 2) {
+  filterAddresses(offset?: number, count?: number, match_owned?: AddressPurpose): Observable<Address[]> {
     offset = offset || 0;
     count = count || null;
-    sort_code = sort_code || 0;
-    search = search || '';
-    match_owned = match_owned || 0;
+    match_owned = match_owned || AddressPurpose.ANY;
+
+    // Always return the newest addresses first
+    const sort_code = 1;
+    const search = '';
+    const sort_key = 'timestamp';
 
     return this.call(Commands.FILTERADDRESSES, [
-      offset, count, sort_code, search, match_owned
+      offset, count, sort_key, sort_code, search, match_owned
     ]);
   }
 

--- a/src/app/wallet/wallet/addresslookup/addresslookup.component.ts
+++ b/src/app/wallet/wallet/addresslookup/addresslookup.component.ts
@@ -26,6 +26,7 @@ import { RpcService, Commands } from '../../../core/core.module';
 import { AddressHelper } from '../../../core/util/utils';
 import { AddressLookUpCopy } from '../models/address-look-up-copy';
 import { Contact } from './contact.model';
+import { AddressPurpose } from 'app/core/rpc/rpc-types';
 
 @Component({
   selector: 'app-addresslookup',
@@ -110,17 +111,17 @@ export class AddressLookupComponent implements OnInit {
     this._rpc.addressBookInfo()
       .subscribe(
         (response: any) => {
-          let typeInt: 0 | 1 | 2 = 0;
+          let purpose: AddressPurpose = AddressPurpose.ANY;
           if (this.type === 'send') {
-            typeInt = 2;
+            purpose = AddressPurpose.SEND;
             this._addressCount = response.num_send;
           } else {
             this.filter = 'Private';
-            typeInt = 1;
+            purpose = AddressPurpose.RECEIVE;
             this._addressCount = response.num_receive;
           }
           if (this._addressCount > 0) {
-            this._rpc.filterAddresses(0, this._addressCount, 0, '', typeInt)
+            this._rpc.filterAddresses(0, this._addressCount, purpose)
               .subscribe(
                 (success: any) => {
                   this.addressLookups = [];

--- a/src/app/wallet/wallet/receive/receive.component.ts
+++ b/src/app/wallet/wallet/receive/receive.component.ts
@@ -23,6 +23,7 @@ import { Log } from 'ng2-logger';
 
 import { RpcService, RpcStateService, Commands } from '../../../core/core.module';
 import { ModalsHelperService } from 'app/modals/modals.module';
+import { Address, AddressPurpose } from 'app/core/rpc/rpc-types';
 
 import { AddAddressLabelComponent } from './modals/add-address-label/add-address-label.component';
 import { SignatureAddressModalComponent } from '../shared/signature-address-modal/signature-address-modal.component';
@@ -247,17 +248,16 @@ export class ReceiveComponent implements OnInit {
       return;
     }
     */
-    this.rpc.filterAddresses(0, count, 0, '', 1)
+    this.rpc.filterAddresses(0, count, AddressPurpose.RECEIVE)
       .subscribe(
-        (resp: Array<any>) => this.rpc_loadAddresses_success(resp),
+        (resp: Array<Address>) => this.rpc_loadAddresses_success(resp),
         error => this.log.er('error', error));
   }
 
   /**
     * Used to get the addresses.
-    * @TODO: Create interface Array<AddressInterface?>
     */
-  rpc_loadAddresses_success(response: Array<any>): void {
+  rpc_loadAddresses_success(response: Array<Address>): void {
     const pub = response;
 
     if (pub.length > 0) {
@@ -267,8 +267,6 @@ export class ReceiveComponent implements OnInit {
     pub .forEach((val) => this.addAddress(val, 'public'));
 
     if (!!response[0]) {
-      this.sortArrays();
-
       this.selectAddress(this.addresses[this.type][0]);
     }
 
@@ -304,7 +302,8 @@ export class ReceiveComponent implements OnInit {
       if (!!response.path) {
         tempAddress.id = response.path.replace('m/0/', '');
       }
-      this.addresses.public.unshift(tempAddress);
+    // Preserve the order in which we received the addresses
+    this.addresses.public.push(tempAddress);
   }
 
   /** Sorts the address by id (= HD wallet path m/0/0 < m/0/1) */

--- a/src/app/wallet/wallet/shared/address.service.ts
+++ b/src/app/wallet/wallet/shared/address.service.ts
@@ -22,6 +22,7 @@ import { Observable, Observer } from 'rxjs'; // use this for testing atm
 
 import { Address, deserialize } from './address.model';
 import { RpcService, Commands } from '../../../core/core.module';
+import { AddressPurpose } from 'app/core/rpc/rpc-types';
 
 
 @Injectable()
@@ -96,11 +97,11 @@ export class AddressService {
 
   private rpc_filterAddresses() {
     if (this.typeOfAddresses === 'send') {
-      return this._rpc.filterAddresses(0, this.addressCount, 0, '',  2);
+      return this._rpc.filterAddresses(0, this.addressCount, AddressPurpose.SEND);
     }  else if (this.typeOfAddresses === 'receive') {
-      return this._rpc.filterAddresses(0, this.addressCount, 0, '',  1);
+      return this._rpc.filterAddresses(0, this.addressCount, AddressPurpose.RECEIVE);
     } else {
-      return this._rpc.filterAddresses(0, this.addressCount, 0, '');
+      return this._rpc.filterAddresses(0, this.addressCount);
     }
   }
 


### PR DESCRIPTION
This makes the wallet order the address book by timestamp, descending, so that the latest created address is always on top and easily accessible.

Fixes #57. 