### PR TITLE
Fix naming in copyright notice and other texts

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -18,8 +18,8 @@ A clear and concise description of what you expected to happen.
 
 **Environment**
 * OS: [e.g. Ubuntu 18.4, MacOS 10.13.6]
-* UnitE version: [e.g. compiled from source from git revision 907fc4f]
-* UnitE UI version: [e.g. version 0.1 from the GitHub release page]
+* unit-e version: [e.g. compiled from source from git revision 907fc4f]
+* unit-e-desktop version: [e.g. version 0.1 from the GitHub release page]
 * Any other relevant system information
 
 **Additional context**

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,8 @@
 # Contributing guidelines
 
-See the [UnitE contributing
+See the [unit-e contributing
 guidelines](https://github.com/dtr-org/unit-e/blob/master/CONTRIBUTING.md). We
-follow the same process for the desktop UI as we do for all other UnitE
+follow the same process for the desktop UI as we do for all other Unit-e
 software.
 
 There is one notable difference. The desktop UI is licensed under the GPLv2 not

--- a/README.md
+++ b/README.md
@@ -2,15 +2,16 @@
 
 ![UI Preview](preview.png)
 
-> *"UnitE is an open source project that aims to provide a lean way to make payments on the internet."*
+> *"Unit-e is an open source project that aims to provide a lean way to make payments on the internet."*
 
-This repository is the user interface that works in combination with our [`unite-core`](https://github.com/drt-org/unit-e).
+This repository is the user interface that works in combination with the
+[`unit-e`](https://github.com/drt-org/unit-e) client.
 
 [Download the packaged wallet for Mac, Windows and Linux](https://github.com/dtr-org/unit-e-desktop/releases)
 
 ## Code of conduct
 
-The UnitE team is committed to fostering a welcoming and harassment-free
+The Unit-e team is committed to fostering a welcoming and harassment-free
 environment. All participants are expected to adhere to our [code of
 conduct](CODE_OF_CONDUCT.md).
 
@@ -125,7 +126,7 @@ Join us in `#unite-core-dev` on FreeNode or on our developer [mailing list](http
 
 ## Copyright
 
-Copyright (C) 2018 UnitE Maintainers.
+Copyright (C) 2018 Unit-e Maintainers.
 
 Portions copyright (C) 2017-2018 Particl Maintainers.
 


### PR DESCRIPTION
Fix the Unit-e naming in the README and the other meta text files
such as CONTRIBUTING and issue templates.
